### PR TITLE
Fix for Content-Type in the rack environment

### DIFF
--- a/spec/rack_handler_jetty_spec.rb
+++ b/spec/rack_handler_jetty_spec.rb
@@ -59,4 +59,9 @@ describe Rack::Handler::Jetty do
     status.should == 403
     response["rack.url_scheme"].should == "http"
   end
+
+  it "should not set content-type to '' in requests" do
+    GET("/test", 'Content-Type' => '')
+    response['Content-Type'].should == nil
+  end
 end


### PR DESCRIPTION
Hi Graham,

rack-jetty triggers this behaviour in Rack:
https://github.com/rack/rack/issues#issue/40

Although a monkey-patch in Rack will fix the issue, and it's conceivable that they should fix things on their side too, at the moment it expects content_type to be either unset (Rack::Lint complains if if env['CONTENT_TYPE'] is present but nil) or a non-empty string (since Rack::Request#media_type kicks out an exception if it's '')

I've put together a commit that addresses the issue in rack-jetty and makes its behaviour w/rt Content-Type the same as the other handlers - if you think it's appropriate, could you accept the pull request and put out a new version of the gem?

I'm just starting to put together an application based on sinatra > rack > rack-jetty > jruby & it'd be nice to avoid the monkey-patching if possible :)

Thanks!
