### PR TITLE
SSL suppoer

### DIFF
--- a/lib/rack/handler/jetty.rb
+++ b/lib/rack/handler/jetty.rb
@@ -6,27 +6,47 @@ module Rack
     class Jetty
       attr_reader :app
       attr_reader :options
-      
+
       def initialize(app, options={})
         @app = app
         @options = options
       end
-      
+
       def self.run(app, options = {})
         new(app,options).run()
       end
-      
+
       def run()
-        @connector = Java::org.mortbay.jetty.bio.SocketConnector.new
+        if options.has_key?(:ssl)
+          ssl = options[:ssl]
+          if ssl.is_a?(Hash) && ssl[:keystore] && ssl[:keystore_password]
+            @connector = Java::org.mortbay.jetty.security.SslSocketConnector.new
+            @connector.set_keystore(ssl[:keystore])
+            @connector.set_password(ssl[:keystore_password])
+            @connector.set_key_password(ssl[:key_password])
+            @connector.set_truststore(ssl[:truststore] || ssl[:keystore])
+            @connector.set_trust_password(
+              ssl[:truststore_password] || ssl[:keystore_password]
+            )
+          else
+            raise ArgumentError.new(
+              "SSL requested but keystore, keystore password or key password" + 
+              "not provided"
+            )
+          end
+        end
+
+        @connector ||= Java::org.mortbay.jetty.bio.SocketConnector.new
+
         @connector.set_host(options[:Host])
         @connector.set_port(options[:Port].to_i)
 
         @jetty = Java::org.mortbay.jetty.Server.new
         @jetty.addConnector(@connector)
-        
+
         bridge = RackJetty::ServletHandler.new
         bridge.handler = self
-        
+
         @jetty.set_handler(bridge)
         @jetty.start
       end
@@ -34,14 +54,16 @@ module Rack
       def running?
         @jetty && @jetty.is_started
       end
-      
+
       def stopped?
         !@jetty || @jetty.is_stopped
       end
-      
+
       def stop()
         @jetty && @jetty.stop
       end
+
     end
   end
 end
+


### PR DESCRIPTION
Hi again.

We find ourselves needing in-process SSL for our project using rack-jetty, which seems to be set up using the following procedure (in Java):

http://actionsresults.com/blog/2009/10/24/embedded-jetty-ssl-https/

This pull implements it, although no tests as yet - I thought I'd ask for feedback first, especially since the tests will require a keystore + truststore to be added to the repository, & I'm not sure what the best values to use / way to test would be.

Plus, the project needs updating for recent rspecs ;) - running the specs, never mind writing them, is a bit of a trial right now. 

If you're interested in adding the code but want tests (and documentation, of course. Can't forget that), I'm happy to pile some more commits on top - just let me know. 
