### PR TITLE
JavaInput doesn't duck-type to IO

### DIFF
--- a/lib/rack_jetty/java_input.rb
+++ b/lib/rack_jetty/java_input.rb
@@ -13,7 +13,7 @@ module RackJetty
       if (count == -1)
         return nil
       end
-      into_buffer << String.from_java_bytes(data[0,count])
+      into_buffer.replace String.from_java_bytes(data[0,count])
       return into_buffer
     end
     

--- a/spec/java_input_spec.rb
+++ b/spec/java_input_spec.rb
@@ -1,0 +1,68 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require 'rack/rewindable_input'
+require 'rack_jetty/java_input'
+require 'java'
+java_import org.jruby.RubyString
+
+class FakeInput
+  def initialize( inner_io )
+    @io = inner_io
+  end
+
+  def read( buffer, offset, length )
+    if length == 0
+      return 0
+    elsif @io.eof?
+      return -1
+    else
+      inbuf = "\0"*length
+      string_read = @io.read( length, inbuf )
+      string_read.length.times do |i|
+        buffer[offset+i] = string_read[i]
+      end
+      string_read.length
+    end
+  end
+end
+
+class ByteAtATimeIO
+  def initialize( content )
+    @io = StringIO.new( content )
+  end
+  
+  def read( n, buf )
+    @io.read( 1, buf )
+  end
+
+  def eof?
+    @io.eof?
+  end
+end
+
+
+describe RackJetty::JavaInput do
+  let( :content ) { "hello world" }
+
+  shared_examples_for "an input stream wrapper" do
+
+    it "should not corrupt input" do
+      stream = FakeInput.new( io )
+      input = RackJetty::JavaInput.new( stream )
+      rio = Rack::RewindableInput.new( input )
+
+      rio.read.should == content
+    end
+  end
+
+  describe "with ordinary IO" do
+    let( :io ) { StringIO.new( content ) }
+    it_behaves_like "an input stream wrapper"
+  end
+
+  describe "with throttled IO" do
+    let( :io ) { ByteAtATimeIO.new( content ) }
+
+    it_behaves_like "an input stream wrapper"
+  end
+
+end


### PR DESCRIPTION
Hi,

There's a problem with the `JavaInput` class which means that it unfortunately breaks if the `InputStream` needs to be read in more than one `read` call.  `IO#read(len, buffer)` is expected to replace the buffer contents with what it gets from the stream, but the current version of `JavaInput` doesn't do that - it appends instead.  This means that, for instance, data being read from an HTTPS POST can be corrupted.  It's a right sod to track down when it happens, too.

I've put together a couple of specs to show the correct behaviour (as relied upon by `Rack::RewindableInput`) so you can see how the breakage shows up, and the fix is very simple.
